### PR TITLE
Add more dispatcher methods

### DIFF
--- a/common/src/main/java/commonnetwork/api/Dispatcher.java
+++ b/common/src/main/java/commonnetwork/api/Dispatcher.java
@@ -1,6 +1,14 @@
 package commonnetwork.api;
 
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerChunkCache;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.chunk.LevelChunk;
+
+import java.util.List;
 
 public class Dispatcher
 {
@@ -38,5 +46,104 @@ public class Dispatcher
     public static <T> void sendToClient(T packet, ServerPlayer player)
     {
         Network.getNetworkHandler().sendToClient(packet, player);
+    }
+
+    /**
+     * Sends the packet to the client players, only if the players has the packet registered.
+     *
+     * @param packet  - the packet
+     * @param players - the players
+     * @param <T>     - The type
+     */
+    public static <T> void sendToClients(T packet, List<ServerPlayer> players)
+    {
+        for (ServerPlayer player : players)
+        {
+            sendToClient(packet, player);
+        }
+    }
+
+    /**
+     * Sends the packet to all the client players in the server, only if the players has the packet registered.
+     *
+     * @param packet - the packet
+     * @param server - the server
+     * @param <T>    - The type
+     */
+    public static <T> void sendToAllClients(T packet, MinecraftServer server)
+    {
+        sendToClients(packet, server.getPlayerList().getPlayers());
+    }
+
+    /**
+     * Sends the packet to all the client players in the level, only if the players has the packet registered.
+     *
+     * @param packet - the packet
+     * @param level  - the level
+     * @param <T>    - The type
+     */
+    public static <T> void sendToClientsInLevel(T packet, ServerLevel level)
+    {
+        sendToClients(packet, level.players());
+    }
+
+    /**
+     * Sends the packet to all the client players loading a chunk, only if the players has the packet registered.
+     *
+     * @param packet - the packet
+     * @param chunk  - the chunk
+     * @param <T>    - The type
+     */
+    public static <T> void sendToClientsLoadingChunk(T packet, LevelChunk chunk)
+    {
+        ServerChunkCache chunkCache = (ServerChunkCache) chunk.getLevel().getChunkSource();
+        sendToClients(packet, chunkCache.chunkMap.getPlayers(chunk.getPos(), false));
+    }
+
+
+    /**
+     * Sends the packet to all the client players loading a position, only if the players has the packet registered.
+     *
+     * @param packet - the packet
+     * @param level  - the level
+     * @param pos    - the chunkpos
+     * @param <T>    - The type
+     */
+    public static <T> void sendToClientsLoadingPos(T packet, ServerLevel level, ChunkPos pos)
+    {
+        sendToClientsLoadingChunk(packet, level.getChunk(pos.x, pos.z));
+    }
+
+    /**
+     * Sends the packet to all the client players loading a position, only if the players has the packet registered.
+     *
+     * @param packet - the packet
+     * @param level  - the level
+     * @param pos    - the blockpos
+     * @param <T>    - The type
+     */
+    public static <T> void sendToClientsLoadingPos(T packet, ServerLevel level, BlockPos pos)
+    {
+        sendToClientsLoadingPos(packet, level, new ChunkPos(pos));
+    }
+
+    /**
+     * Sends the packet to all the client players in range of a position, only if the players has the packet registered.
+     *
+     * @param packet - the packet
+     * @param level  - the level
+     * @param pos    - the blockpos
+     * @param range  - the range
+     * @param <T>    - The type
+     */
+    public static <T> void sendToClientsInRange(T packet, ServerLevel level, BlockPos pos, double range)
+    {
+        for (ServerPlayer player : level.players())
+        {
+            if (player.distanceToSqr(pos.getX(), pos.getY(), pos.getZ()) <= range * range)
+            {
+                sendToClient(packet, player);
+            }
+        }
     }
 }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -126,6 +126,13 @@ publishing {
     }
 }
 
+if (!project.hasProperty("curseForgeApiKey")) {
+    ext.curseForgeApiKey = "notset"
+}
+if (!project.hasProperty("modrinthApiKey")) {
+    ext.modrinthApiKey = "notset"
+}
+
 curseforge {
     project {
         id = '806044'


### PR DESCRIPTION
### What does this PR change?

This adds several new dispatcher methods that allow for easier dispatching of packets to clients.
The new methods include:
- Dispatching to several clients
- Dispatching to the whole server
- Dispatching to all players in a level/dimension
- Dispatching to all players tracking/loading a chunk
- Dispatching to all players tracking/loading a position, either a blockpos or chunkpos
- Dispatching to all players within range of a position

This PR also adds the same check that was in the neoforge and forge gradle files to fabric to allow for loading of project with missing properties for API keys.