### PR TITLE
Add Library badge to Mod Menu metadata

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -23,7 +23,8 @@
       "links": {
         "modmenu.discord": "https://discord.gg/eP8gE69",
         "github": "https://github.com/mysticdrew/common-networking"
-      }
+      },
+      "badges": [ "library" ]
     }
   },
   "depends": {


### PR DESCRIPTION
I noticed Common Networking wasn't hidden inside the list of mods of Mod Menu with "Libraries: Hidden". This adds the library badge so that it is.

![2024-04-27_15 14 31](https://github.com/mysticdrew/common-networking/assets/38502394/c3469989-930b-468a-970d-bc0d73fdee31)
